### PR TITLE
Rename the-algorithm to a more subjective name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twitter Recommendation Algorithm
+# ChirpChoice Algorithm
 
 The Twitter Recommendation Algorithm is a set of services and jobs that are responsible for constructing and serving the
 Home Timeline. For an introduction to how the algorithm works, please refer to our [engineering blog](https://blog.twitter.com/engineering/en_us/topics/open-source/2023/twitter-recommendation-algorithm). The


### PR DESCRIPTION
I propose to change the repository name to something subjective. `The-Algorithm` sounds like a movie name. This is the first one to go open source , but definitely not the last. Keeping algorithm names subjective or giving it a proper noun makes it easier for users to understand and relate, here are some suggestions from OpenAI :

![image](https://user-images.githubusercontent.com/42934221/229214075-7b4c668a-5aa5-4bd2-adb2-453e2a2974de.png)

Disclaimer : My PR doesn't intent to rename the algorithm to `ChirpChoice` , it's just to highlight that we should rename 😄 
